### PR TITLE
Moved initialization of 'current_scan'

### DIFF
--- a/PingCastle-Notify.ps1
+++ b/PingCastle-Notify.ps1
@@ -239,6 +239,7 @@ $BodyTeams = Update_Body($BodyTeams)
 
 $old_report = (Get-ChildItem -Path "Reports" -Filter "*.xml" -Attributes !Directory | Sort-Object -Descending -Property LastWriteTime | select -First 1)
 $old_report.FullName
+$current_scan = ""
 $final_thread = ""
 # Check if PingCastle previous score file exist
 if (-not ($old_report.FullName)) {
@@ -258,7 +259,6 @@ if (-not ($old_report.FullName)) {
     }
     $final_thread = $result
 } else {
-    $current_scan = ""
     $newCategoryContent = $Anomalies + $PrivilegedAccounts + $StaleObjects + $Trusts 
     Foreach ($rule in $newCategoryContent) {
 


### PR DESCRIPTION
When running the tool the first time, the variable 'current_scan' is not defined. However, sending a notification to a Teams channel requires this value to be set. To prevent trying to call the 'replace' method in line 370 on a null-valued expression, I moved the initialization of 'current_scan' so that it's defined for every execution.