### PR TITLE
mega refactor

### DIFF
--- a/modules/Slack.psm1
+++ b/modules/Slack.psm1
@@ -103,7 +103,6 @@ function Send-SlackMessage {
     
     try {
         $BodySlackJson = $body | ConvertTo-Json -Depth 5
-        Write-Host $BodySlackJson
         Write-Host "Sending to slack"
         $response = Invoke-RestMethod -Uri https://slack.com/api/chat.postMessage -Headers $script:headers -Body $BodySlackJson -Method Post -ContentType 'application/json'
         


### PR DESCRIPTION
This pull request refactors `PingCastle-Notify.ps1` to support dynamic connector modules, making the notification system extensible beyond Slack and Teams. It replaces hardcoded logic with generic functions that automatically detect, initialize, and interact with any connector module found in the `modules` directory. The changes also streamline message formatting, sending, and logging for all enabled connectors.

**Connector Module System Refactor**

* Replaced hardcoded Slack and Teams imports and initialization with dynamic detection and loading of all connector modules in the `modules` directory, including automatic configuration and enabled status checks. (`PingCastle-Notify.ps1`, [PingCastle-Notify.ps1L58-L73](diffhunk://#diff-4642e9232adbecade8ae4881d3ea408f7ad1f4665ee0bbe4566a10c0d239e83eL58-L73))
* Refactored body update and status message functions to generically handle all connectors, removing explicit references to Slack and Teams and enabling easy addition of new connectors. (`PingCastle-Notify.ps1`, [PingCastle-Notify.ps1R139-R250](diffhunk://#diff-4642e9232adbecade8ae4881d3ea408f7ad1f4665ee0bbe4566a10c0d239e83eR139-R250))
* Updated scan data integration and first scan logic to use connector-agnostic functions, ensuring all enabled connectors receive appropriate message updates. (`PingCastle-Notify.ps1`, [[1]](diffhunk://#diff-4642e9232adbecade8ae4881d3ea408f7ad1f4665ee0bbe4566a10c0d239e83eL317-R400) [[2]](diffhunk://#diff-4642e9232adbecade8ae4881d3ea408f7ad1f4665ee0bbe4566a10c0d239e83eL332-R413) [[3]](diffhunk://#diff-4642e9232adbecade8ae4881d3ea408f7ad1f4665ee0bbe4566a10c0d239e83eL383-L405)

**Notification Sending and Logging**

* Unified message sending for all enabled connectors through a single function, handling special cases like Teams message formatting and Slack thread replies, and improved logging to use any available connector body. (`PingCastle-Notify.ps1`, [PingCastle-Notify.ps1L422-R527](diffhunk://#diff-4642e9232adbecade8ae4881d3ea408f7ad1f4665ee0bbe4566a10c0d239e83eL422-R527))

**Minor Cleanups**

* Removed unnecessary debug output from the Slack module to reduce console noise. (`modules/Slack.psm1`, [modules/Slack.psm1L106](diffhunk://#diff-6cec35e7a9abc3b515b1e7b61ceb3b6f33a8e797cb288a221f74bfee3ab91355L106))