### PR TITLE
remove comment

### DIFF
--- a/PingCastle-Notify.ps1
+++ b/PingCastle-Notify.ps1
@@ -369,7 +369,7 @@ try {
     Set-Location -Path $PingCastle.ProgramPath
     Write-Host ""
     Write-Host "[+] Running PingCastle scan"
-    #Start-Process -FilePath $pingCastleFullpath -ArgumentList $PingCastle.Arguments @splatProcess
+    Start-Process -FilePath $pingCastleFullpath -ArgumentList $PingCastle.Arguments @splatProcess
 }
 Catch {
     Write-Error -Message ("Error for execute {0}" -f $pingCastleFullpath)
@@ -547,11 +547,11 @@ try {
         Write-Information $log
     }
 
-    # $pingCastleMoveFile = (Join-Path $pingCastleReportLogs $pingCastleReportFileNameDate)
-    # Move-Item -Path $pingCastleReportFullpath -Destination $pingCastleMoveFile
-    # $pingCastleMoveFile = (Join-Path $pingCastleReportLogs $pingCastleReportFileNameDateXML)
-    # Move-Item -Path $pingCastleReportXMLFullpath -Destination $pingCastleMoveFile
-    # Remove-Item ("{0}.{1}" -f (Join-Path $PingCastle.ProgramPath $PingCastle.ReportFileName), '*')
+    $pingCastleMoveFile = (Join-Path $pingCastleReportLogs $pingCastleReportFileNameDate)
+    Move-Item -Path $pingCastleReportFullpath -Destination $pingCastleMoveFile
+    $pingCastleMoveFile = (Join-Path $pingCastleReportLogs $pingCastleReportFileNameDateXML)
+    Move-Item -Path $pingCastleReportXMLFullpath -Destination $pingCastleMoveFile
+    Remove-Item ("{0}.{1}" -f (Join-Path $PingCastle.ProgramPath $PingCastle.ReportFileName), '*')
 }
 catch {
     Write-Error -Message ("Error for move report file to logs directory {0}" -f $pingCastleReportFullpath)


### PR DESCRIPTION
This pull request enables previously commented-out functionality in the `PingCastle-Notify.ps1` script, allowing the PingCastle scan to execute and its report files to be moved and cleaned up as intended.

**Execution improvements:**

* The PingCastle scan is now started by uncommenting the `Start-Process` command, ensuring the scan actually runs when the script is executed.

**Report management enhancements:**

* The script now moves the generated PingCastle report and XML files to the logs directory and removes old report files, improving file organization and cleanup.