### PR TITLE
Comment out Write-Information for old report #33

### DIFF
--- a/PingCastle-Notify.ps1
+++ b/PingCastle-Notify.ps1
@@ -642,7 +642,7 @@ if ($enabledConnectors["Slack"]) {
 # Update all connector bodies with scan data
 $connectorBodies = Update-ConnectorBodies $connectorBodies $domainName $dateScan $total_point $str_trusts $str_staleObject $str_privilegeAccount $str_anomalies $anssiMaturityText
 $old_report = (Get-ChildItem -Path "Reports" -Filter "*.xml" -Attributes !Directory | Sort-Object -Descending -Property LastWriteTime | select -First 1)
-Write-Information $old_report.FullName
+# Write-Information $old_report.FullName
 $current_scan = ""
 $final_thread = ""
 # Check if PingCastle previous score file exist


### PR DESCRIPTION
This pull request makes a minor change to the logging behavior in the Slack connector section of `PingCastle-Notify.ps1`. Specifically, it comments out a line that previously wrote information about the latest report file.

* Logging adjustment: Commented out the `Write-Information $old_report.FullName` line to suppress output of the latest report file name in the Slack connector workflow.